### PR TITLE
Fixed setup.py to not use setuptools.command.test.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -80,6 +80,7 @@ switch, and thus all their contributions are dual-licensed.
 - Matthew Schinckel <matt@MASKED>
 - Max Shenfield <shenfieldmax@MASKED>
 - Maxime Lorant <maxime.lorant@MASKED>
+- Md Safiyat Reza <reza.safiyat@MASKED> (gh: @safiyat) **D**
 - Michael Aquilina <michaelaquilina@MASKED> (gh: @MichaelAquilina)
 - Michael J. Schultz <mjschultz@MASKED>
 - Michael Käufl (gh: @michael-k)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,11 @@ if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
 
 
 class Unsupported(Command):
+    """Unsupported command class.
+    """
     def run(self):
+        """The overridden run method of the parent class.
+        """
         sys.stderr.write("Running 'test' with setup.py is not supported. "
                          "Use 'pytest' or 'tox' to run the tests.\n")
         sys.exit(1)
@@ -30,7 +34,12 @@ class Unsupported(Command):
 ###
 # Load metadata
 
-def README():
+def readme():
+    """Function to read and return the updated README.rst file.
+
+    Returns:
+        str: The modified contents of README.rst.
+    """
     with io.open('README.rst', encoding='utf-8') as f:
         readme_lines = f.readlines()
 
@@ -43,15 +52,17 @@ def README():
             lines_out.append(line)
 
     return ''.join(lines_out)
-README = README()  # NOQA
+
+
+README = readme()
 
 
 setup(
       use_scm_version={
           'write_to': 'src/dateutil/_version.py',
       },
-      ## Needed since doctest not supported by PyPA.
-      long_description = README,
+      # Needed since doctest not supported by PyPA.
+      long_description=README,
       cmdclass={
           "test": Unsupported
       }

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from os.path import isfile
 import os
 
 import setuptools
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
+from setuptools import setup
+from setuptools import Command
 
 from distutils.version import LooseVersion
 import warnings
@@ -20,7 +20,7 @@ if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
                   UserWarning)
 
 
-class Unsupported(TestCommand):
+class Unsupported(Command):
     def run(self):
         sys.stderr.write("Running 'test' with setup.py is not supported. "
                          "Use 'pytest' or 'tox' to run the tests.\n")


### PR DESCRIPTION
setuptools.command.test is removed in setuptools>=72.0.0. Discussion: https://github.com/pypa/setuptools/issues/931

This breaks dateutil as it was using `setuptools.command.test.test` as `TestCommand`.

Changed it to `setuptools.Command`.